### PR TITLE
Create new processes with spawn instead of fork

### DIFF
--- a/ctc_to_cb/run_ingest_threads.py
+++ b/ctc_to_cb/run_ingest_threads.py
@@ -70,7 +70,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from multiprocessing import JoinableQueue, Queue
+from multiprocessing import JoinableQueue, Queue, set_start_method
 from pathlib import Path
 from typing import Callable
 
@@ -264,6 +264,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry for run_ingest_threads
         """
+        # Force new processes to start with a clean environment
+        # "fork" is the default on Linux and can be unsafe
+        set_start_method("spawn")
+
         # Setup logging for the main process so we can use the "logger"
         log_queue = Queue()
         runtime = datetime.now()

--- a/grib2_to_cb/run_ingest_threads.py
+++ b/grib2_to_cb/run_ingest_threads.py
@@ -70,7 +70,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from multiprocessing import JoinableQueue, Queue
+from multiprocessing import JoinableQueue, Queue, set_start_method
 from pathlib import Path
 from typing import Callable
 
@@ -279,6 +279,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry for run_ingest_threads
         """
+        # Force new processes to start with a clean environment
+        # "fork" is the default on Linux and can be unsafe
+        set_start_method("spawn")
+
         # Setup logging for the main process so we can use the "logger"
         log_queue = Queue()
         runtime = datetime.now()

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 import tarfile
 from datetime import datetime, timedelta
-from multiprocessing import Queue
+from multiprocessing import Queue, set_start_method
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
 
@@ -484,6 +484,10 @@ def process_jobs(
 
 def run_ingest() -> None:
     """entrypoint"""
+    # Force new processes to start with a clean environment
+    # "fork" is the default on Linux and can be unsafe
+    set_start_method("spawn")
+
     args = process_cli()
 
     # Setup logging for the main process so we can use the "logger"

--- a/netcdf_to_cb/run_ingest_threads.py
+++ b/netcdf_to_cb/run_ingest_threads.py
@@ -70,7 +70,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from multiprocessing import JoinableQueue, Queue
+from multiprocessing import JoinableQueue, Queue, set_start_method
 from pathlib import Path
 from typing import Callable
 
@@ -265,6 +265,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry for run_ingest_threads
         """
+        # Force new processes to start with a clean environment
+        # "fork" is the default on Linux and can be unsafe
+        set_start_method("spawn")
+
         # Setup logging for the main process so we can use the "logger"
         log_queue = Queue()
         runtime = datetime.now()

--- a/partial_sums_to_cb/run_ingest_threads.py
+++ b/partial_sums_to_cb/run_ingest_threads.py
@@ -70,7 +70,7 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from multiprocessing import JoinableQueue, Queue
+from multiprocessing import JoinableQueue, Queue, set_start_method
 from pathlib import Path
 from typing import Callable
 
@@ -256,6 +256,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry for run_ingest_threads
         """
+        # Force new processes to start with a clean environment
+        # "fork" is the default on Linux and can be unsafe
+        set_start_method("spawn")
+
         # Setup logging for the main process so we can use the "logger"
         log_queue = Queue()
         runtime = datetime.now()


### PR DESCRIPTION
Fork can be dangerous as it copies parent processes variables, including lock states but not the threads that can unlock them. Python is changing this default in 3.14. However, for now we have to manually specify that we want to "spawn" new processes with a clean slate instead of "fork"-ing them.

This was causing deadlock errors with our logging thread. There's some debate if we should even be using a thread in the main process while we're using multiprocessing elsewhere.

Closes #273 