### PR TITLE
Switch docker compose to use images from ci

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,10 +5,7 @@ secrets:
 
 services:
   shell:
-    build:
-      context: .
-      dockerfile: docker/ingest/Dockerfile
-      target: prod
+    image: ghcr.io/noaa-gsl/vxingest/ingest:main
     volumes:
       - ${data}:/opt/data
       - ${public}:/public
@@ -16,9 +13,9 @@ services:
       - CREDENTIALS_FILE
     environment:
     - CREDENTIALS=/run/secrets/CREDENTIALS_FILE
-    command: /bin/bash
+    entrypoint: /bin/bash
   test:
-    build:
+    build: # build the image so we can specify the target
       context: .
       dockerfile: docker/ingest/Dockerfile
       target: dev
@@ -31,10 +28,7 @@ services:
     command: poetry run pytest tests
   # FIXME - add a way to specify unit & integration tests
   ingest:
-    build:
-      context: .
-      dockerfile: docker/ingest/Dockerfile
-      target: prod
+    image: ghcr.io/noaa-gsl/vxingest/ingest:main
     volumes:
       - ${data}:/opt/data
       - ${public}:/public
@@ -47,9 +41,7 @@ services:
       - "--metrics_dir=/opt/data/test/metrics"
       - "--transfer_dir=/opt/data/test/xfer"
   import:
-    build:
-      context: .
-      dockerfile: docker/import/Dockerfile
+    image: ghcr.io/noaa-gsl/vxingest/import:main
     volumes:
       - ${data}:/opt/data
     secrets:

--- a/docker/import/Dockerfile
+++ b/docker/import/Dockerfile
@@ -13,20 +13,21 @@ ENV VERSION=${BUILDVER}
 
 LABEL version=${BUILDVER} code.branch=${COMMITBRANCH} code.commit=${COMMITSHA}
 
+# Specify the UID/GID we want our user to have.
+# In this case, use the same uid/gid as the ingest image.
+ARG ID=5002
+ARG USERNAME=import
+
+# Add a user with a known uid/gid
+# Create a home dir so we have a place for temporary cache dirs & etc...
+RUN groupadd --gid ${ID} ${USERNAME} && \
+    useradd --shell /bin/bash --create-home --uid ${ID} --gid ${ID} ${USERNAME}
+
 # Run OS updates
 RUN apt-get update && apt-get upgrade -y && \
     # Install runtime deps for the script
     apt-get install -y curl jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
-
-# Specify the UID/GID we want our user to have.
-# In this case, use the same uid/gid as the local amb-verif user.
-ENV ID=5002
-
-# Add a user with a known uid/gid
-# Create a home dir so we have a place for temporary cache dirs & etc...
-RUN groupadd --gid ${ID} amb-verif && \
-    useradd --shell /bin/bash --create-home --uid ${ID} --gid ${ID} amb-verif
 
 WORKDIR /app
 
@@ -41,6 +42,6 @@ COPY ./mats_metadata_and_indexes /app/mats_metadata_and_indexes
 # TODO - install the cbtools directly and remove from the git repo
 # See: https://docs.couchbase.com/cloud/reference/command-line-tools.html#download-and-install-the-couchbase-command-line-tools
 
-USER amb-verif
+USER ${USERNAME}
 
 ENTRYPOINT ["bash", "./scripts/VXingest_utilities/run-import.sh"]

--- a/docker/ingest/Dockerfile
+++ b/docker/ingest/Dockerfile
@@ -96,13 +96,14 @@ ENV ECCODES_DEFINITION_PATH=/usr/local/share/eccodes/definitions/ \
 WORKDIR /app
 
 # Specify the UID/GID we want our user to have.
-# In this case, use the same uid/gid as the local amb-verif user.
-ENV ID=5002
+# In this case, use the same uid/gid as the import image.
+ARG ID=5002
+ARG USERNAME=ingest
 
 # Add a user with a known uid/gid
 # Create a home dir so we have a place for temporary cache dirs & etc...
-RUN groupadd --gid ${ID} python && \
-    useradd --shell /bin/bash --create-home --uid ${ID} --gid ${ID} python
+RUN groupadd --gid ${ID} ${USERNAME} && \
+    useradd --shell /bin/bash --create-home --uid ${ID} --gid ${ID} ${USERNAME}
 
 # Run OS updates
 RUN apt-get update && apt-get upgrade -y && \
@@ -113,6 +114,6 @@ RUN apt-get update && apt-get upgrade -y && \
 # Copy just the vxingest app
 COPY ./src/ /app/
 
-USER python
+USER ${USERNAME}
 
 ENTRYPOINT ["python", "-m", "vxingest.main"]

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -100,7 +100,7 @@ docker build \
     .
 ```
 
-And run it via Docker Compose with the below. Note the `data` and `public` env variables point to where the input data resides and where you'd like the container to write out to. These are currently (12/2023) mounted to `/opt/data` inside the container.
+And run it via Docker Compose with the below. You'll need to update the `compose.yaml` file in the repo with your image tag. Note the `data` and `public` env variables point to where the input data resides and where you'd like the container to write out to. These are currently (12/2023) mounted to `/opt/data` inside the container.
 
 ```bash
 data=/data-ingest/data \
@@ -173,6 +173,8 @@ data=/data-ingest/data \
 
 There is currently a Docker Compose file with options to run unit tests and ingest from within the container. This may be a useful option for local development as well.
 
+*NOTE*: if you're using Rancher Desktop, you won't be able to access /opt on your system as it's not mounted into the VM by default. You'll need to move your test files into your home directory.
+
 * `shell`: expects /data and /public for mounting
 * `test`: expects /opt/data for mounting
 * `ingest`: expects /data and /public for mounting
@@ -181,7 +183,7 @@ There is currently a Docker Compose file with options to run unit tests and inge
 And can be run like:
 
 ```bash
-data=/opt/data docker compose run test
+data=/home/path/to/a/copy/of/opt/data docker compose run test
 ```
 
 ## Notes


### PR DESCRIPTION
Switch to using prebuilt images for most of the compose file. I left the `test` target alone as it needs to build its own image as it relies on a build stage in the Dockerfile to have the test suite available. 

Also updated the documentation.

I left the UID/GID alone - they aren't centrally managed on the hosts by IT and currently differ between the nodes we're using anyway. 

Closes #288