### PR TITLE
Add tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           filename: coverage.xml
           badge: true
           fail_below_min: false
+          hide_complexity: true
           format: markdown
           output: both
           thresholds: "50 80"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,15 @@ jobs:
           hide_complexity: true
           format: markdown
           output: both
-          thresholds: "50 80"
+          thresholds: "60 80"
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
           recreate: true
           path: code-coverage-results.md
+      - name: Add Coverage to Job Summary
+        run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
   build-ingest:
     name: Build Ingest image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
           poetry env use 3.11
           poetry install
       - name: Unit test with pytest
-        run: poetry run pytest -m "not integration" --cov=vxingest --cov-report=xml tests
+        run: | 
+          poetry run coverage run -m pytest tests
+          poetry run coverage report
+          poetry run coverage xml
       - name: Code Coverage Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,21 @@ jobs:
         run: poetry run ruff format --check src tests
       - name: Lint with Ruff
         run: poetry run ruff check --output-format=github src tests
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          poetry env use 3.11
+          poetry install
+      - name: Unit test with pytest
+        run: poetry run pytest -m "not integration" tests
   build-ingest:
     name: Build Ingest image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,27 @@ jobs:
           poetry env use 3.11
           poetry install
       - name: Unit test with pytest
-        run: poetry run pytest -m "not integration" tests
+        run: poetry run pytest -m "not integration" --cov=vxingest --cov-report=xml tests
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          header: Test Coverage Report
+          filename: coverage.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          output: both
+          thresholds: "50 80"
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md
   build-ingest:
     name: Build Ingest image
     runs-on: ubuntu-latest
+    needs: [ lint, test ]
     permissions:
       packages: write
     steps:
@@ -91,6 +108,7 @@ jobs:
   build-import:
     name: Build Import image
     runs-on: ubuntu-latest
+    needs: [ lint, test ]
     permissions:
       packages: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           poetry install
       - name: Unit test with pytest
         run: | 
-          poetry run coverage run -m pytest tests
+          poetry run coverage run -m pytest -m "not integration" tests
           poetry run coverage report
           poetry run coverage xml
       - name: Code Coverage Report

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -68,6 +68,10 @@ poetry run ruff format .
 poetry run mypy src
 # Unit test
 CREDENTIALS=config.yaml poetry run pytest tests
+# Coverage report
+CREDENTIALS=config.yaml poetry run coverage run -m pytest tests && \
+    poetry run coverage report && \
+    poetry run coverage html
 ```
 
 ### Testing

--- a/poetry.lock
+++ b/poetry.lock
@@ -1159,24 +1159,6 @@ pluggy = ">=0.12,<2.0"
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-cov"
-version = "4.1.0"
-description = "Pytest plugin for measuring coverage."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
-]
-
-[package.dependencies]
-coverage = {version = ">=5.2.1", extras = ["toml"]}
-pytest = ">=4.6"
-
-[package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
-
-[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1440,4 +1422,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "815e94ae4073e6e59b873ab15a16e5dbc6a96eaee132cfb3badd7aebc10c9ac1"
+content-hash = "776a359d50f8dd24a53154023b1bae1ef3823a060a5df49bb68ebc7d2650e7bf"

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,6 +372,70 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.4.0"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36b0ea8ab20d6a7564e89cb6135920bc9188fb5f1f7152e94e8300b7b189441a"},
+    {file = "coverage-7.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0676cd0ba581e514b7f726495ea75aba3eb20899d824636c6f59b0ed2f88c471"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ca5c71a5a1765a0f8f88022c52b6b8be740e512980362f7fdbb03725a0d6b9"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7c97726520f784239f6c62506bc70e48d01ae71e9da128259d61ca5e9788516"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:815ac2d0f3398a14286dc2cea223a6f338109f9ecf39a71160cd1628786bc6f5"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:80b5ee39b7f0131ebec7968baa9b2309eddb35b8403d1869e08f024efd883566"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5b2ccb7548a0b65974860a78c9ffe1173cfb5877460e5a229238d985565574ae"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:995ea5c48c4ebfd898eacb098164b3cc826ba273b3049e4a889658548e321b43"},
+    {file = "coverage-7.4.0-cp310-cp310-win32.whl", hash = "sha256:79287fd95585ed36e83182794a57a46aeae0b64ca53929d1176db56aacc83451"},
+    {file = "coverage-7.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:5b14b4f8760006bfdb6e08667af7bc2d8d9bfdb648351915315ea17645347137"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:04387a4a6ecb330c1878907ce0dc04078ea72a869263e53c72a1ba5bbdf380ca"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea81d8f9691bb53f4fb4db603203029643caffc82bf998ab5b59ca05560f4c06"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74775198b702868ec2d058cb92720a3c5a9177296f75bd97317c787daf711505"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76f03940f9973bfaee8cfba70ac991825611b9aac047e5c80d499a44079ec0bc"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:485e9f897cf4856a65a57c7f6ea3dc0d4e6c076c87311d4bc003f82cfe199d25"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6ae8c9d301207e6856865867d762a4b6fd379c714fcc0607a84b92ee63feff70"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bf477c355274a72435ceb140dc42de0dc1e1e0bf6e97195be30487d8eaaf1a09"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:83c2dda2666fe32332f8e87481eed056c8b4d163fe18ecc690b02802d36a4d26"},
+    {file = "coverage-7.4.0-cp311-cp311-win32.whl", hash = "sha256:697d1317e5290a313ef0d369650cfee1a114abb6021fa239ca12b4849ebbd614"},
+    {file = "coverage-7.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:26776ff6c711d9d835557ee453082025d871e30b3fd6c27fcef14733f67f0590"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:13eaf476ec3e883fe3e5fe3707caeb88268a06284484a3daf8250259ef1ba143"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846f52f46e212affb5bcf131c952fb4075b55aae6b61adc9856222df89cbe3e2"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26f66da8695719ccf90e794ed567a1549bb2644a706b41e9f6eae6816b398c4a"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:164fdcc3246c69a6526a59b744b62e303039a81e42cfbbdc171c91a8cc2f9446"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:316543f71025a6565677d84bc4df2114e9b6a615aa39fb165d697dba06a54af9"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bb1de682da0b824411e00a0d4da5a784ec6496b6850fdf8c865c1d68c0e318dd"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:0e8d06778e8fbffccfe96331a3946237f87b1e1d359d7fbe8b06b96c95a5407a"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a56de34db7b7ff77056a37aedded01b2b98b508227d2d0979d373a9b5d353daa"},
+    {file = "coverage-7.4.0-cp312-cp312-win32.whl", hash = "sha256:51456e6fa099a8d9d91497202d9563a320513fcf59f33991b0661a4a6f2ad450"},
+    {file = "coverage-7.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd3c1e4cb2ff0083758f09be0f77402e1bdf704adb7f89108007300a6da587d0"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9d1bf53c4c8de58d22e0e956a79a5b37f754ed1ffdbf1a260d9dcfa2d8a325e"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:109f5985182b6b81fe33323ab4707011875198c41964f014579cf82cebf2bb85"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc9d4bc55de8003663ec94c2f215d12d42ceea128da8f0f4036235a119c88ac"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc6d65b21c219ec2072c1293c505cf36e4e913a3f936d80028993dd73c7906b1"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a10a4920def78bbfff4eff8a05c51be03e42f1c3735be42d851f199144897ba"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b8e99f06160602bc64da35158bb76c73522a4010f0649be44a4e167ff8555952"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7d360587e64d006402b7116623cebf9d48893329ef035278969fa3bbf75b697e"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:29f3abe810930311c0b5d1a7140f6395369c3db1be68345638c33eec07535105"},
+    {file = "coverage-7.4.0-cp38-cp38-win32.whl", hash = "sha256:5040148f4ec43644702e7b16ca864c5314ccb8ee0751ef617d49aa0e2d6bf4f2"},
+    {file = "coverage-7.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:9864463c1c2f9cb3b5db2cf1ff475eed2f0b4285c2aaf4d357b69959941aa555"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:936d38794044b26c99d3dd004d8af0035ac535b92090f7f2bb5aa9c8e2f5cd42"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:799c8f873794a08cdf216aa5d0531c6a3747793b70c53f70e98259720a6fe2d7"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7defbb9737274023e2d7af02cac77043c86ce88a907c58f42b580a97d5bcca9"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1526d265743fb49363974b7aa8d5899ff64ee07df47dd8d3e37dcc0818f09ed"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf635a52fc1ea401baf88843ae8708591aa4adff875e5c23220de43b1ccf575c"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:756ded44f47f330666843b5781be126ab57bb57c22adbb07d83f6b519783b870"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0eb3c2f32dabe3a4aaf6441dde94f35687224dfd7eb2a7f47f3fd9428e421058"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfd5db349d15c08311702611f3dccbef4b4e2ec148fcc636cf8739519b4a5c0f"},
+    {file = "coverage-7.4.0-cp39-cp39-win32.whl", hash = "sha256:53d7d9158ee03956e0eadac38dfa1ec8068431ef8058fe6447043db1fb40d932"},
+    {file = "coverage-7.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:cfd2a8b6b0d8e66e944d47cdec2f47c48fef2ba2f2dff5a9a75757f64172857e"},
+    {file = "coverage-7.4.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:c530833afc4707fe48524a44844493f36d8727f04dcce91fb978c414a8556cc6"},
+    {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -1095,6 +1159,24 @@ pluggy = ">=0.12,<2.0"
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "4.1.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1131,7 +1213,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1139,15 +1220,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1164,7 +1238,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1172,7 +1245,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1368,4 +1440,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "77b941447f5222afe1c9b0912f313831ec5bb0408f69af4e733f837d85294474"
+content-hash = "815e94ae4073e6e59b873ab15a16e5dbc6a96eaee132cfb3badd7aebc10c9ac1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ prometheus-client = "^0.19.0"
 pytest = "^7.4.3"
 types-pyyaml = "^6.0.12.12"
 ruff = "^0.1.6"
-pytest-cov = "^4.1.0"
+coverage = "^7.4.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -37,3 +37,6 @@ ingest = "vxingest.main:run_ingest"
 markers = [
     "integration: marks tests that need external resources like databases or data files (deselect with '-m \"not integration\"')",
 ]
+
+[tool.coverage.run]
+branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ prometheus-client = "^0.19.0"
 pytest = "^7.4.3"
 types-pyyaml = "^6.0.12.12"
 ruff = "^0.1.6"
+pytest-cov = "^4.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 ingest = "vxingest.main:run_ingest"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that need external resources like databases or data files (deselect with '-m \"not integration\"')",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,4 @@ markers = [
 
 [tool.coverage.run]
 branch = true
-source = "src"
+source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ markers = [
 
 [tool.coverage.run]
 branch = true
+source = "src"

--- a/tests/vxingest/README.md
+++ b/tests/vxingest/README.md
@@ -23,7 +23,7 @@ CREDENTIALS=config.yaml poetry run pytest tests/vxingest/ctc_to_cb
 You can create a coverage report with:
 
 ```shell
-CREDENTIALS=config.yaml poetry run coverage run --branch -m pytest tests
+CREDENTIALS=config.yaml poetry run coverage run -m pytest tests
 poetry run coverage report
 poetry run coverage html
 ```

--- a/tests/vxingest/README.md
+++ b/tests/vxingest/README.md
@@ -20,7 +20,23 @@ You can specify certain directories to limit which tests are run.
 CREDENTIALS=config.yaml poetry run pytest tests/vxingest/ctc_to_cb
 ```
 
-Note that for now, you'll need some test data & a connection to our couchbase cluster in order to run the test suite.
+You can create a coverage report with:
+
+```shell
+CREDENTIALS=config.yaml poetry run coverage run --branch -m pytest tests
+poetry run coverage report
+poetry run coverage html
+```
+
+Then open `./htmlcov/index.html` in your browser for a detailed dive into what lines were run by the test suite.
+
+Lastly, you can disable tests that require external resources (database connections & raw data files) like so:
+
+```shell
+CREDENTIALS=config.yaml poetry run pytest -m "not integration" tests
+```
+
+Note that this currently (as of 1/2024) disables most of the tests.
 
 ## Test data
 

--- a/tests/vxingest/builder_common/test_unit_queries.py
+++ b/tests/vxingest/builder_common/test_unit_queries.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -42,6 +43,7 @@ def connect_cb():
     return cb_connection
 
 
+@pytest.mark.integration()
 def test_stations_fcst_valid_epoch(request):
     _expected_time = 10
     _name = request.node.name
@@ -61,6 +63,7 @@ def test_stations_fcst_valid_epoch(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_stations_get_file_list_grib2(request):
     _expected_time = 10
     _name = request.node.name
@@ -78,6 +81,7 @@ def test_stations_get_file_list_grib2(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_stations_get_file_list_netcdf(request):
     _expected_time = 5
     _name = request.node.name
@@ -95,6 +99,7 @@ def test_stations_get_file_list_netcdf(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_metar_count(request):
     _expected_time = 0.05
     _name = request.node.name

--- a/tests/vxingest/ctc_to_cb/test_int_metar_ctc.py
+++ b/tests/vxingest/ctc_to_cb/test_int_metar_ctc.py
@@ -36,6 +36,7 @@ def stub_worker_log_configurer(queue: Queue):
     pass
 
 
+@pytest.mark.integration()
 def test_check_fcst_valid_epoch_fcst_valid_iso():
     """
     integration test to check fcst_valid_epoch is derived correctly
@@ -81,6 +82,7 @@ def test_check_fcst_valid_epoch_fcst_valid_iso():
         assert (fve % 3600) == 0, "fcstValidEpoch is not at top of hour"
 
 
+@pytest.mark.integration()
 def test_get_stations_geo_search():
     """
     Currently we know that there are differences between the geo search stations list and the legacy
@@ -285,6 +287,7 @@ def calculate_cb_ctc(
     return ctc
 
 
+@pytest.mark.integration()
 def test_ctc_builder_ceiling_hrrr_ops_all_hrrr():
     """
     This test verifies that data is returned for each fcstLen and each threshold.
@@ -376,6 +379,7 @@ def test_ctc_builder_ceiling_hrrr_ops_all_hrrr():
                 continue
 
 
+@pytest.mark.integration()
 def test_ctc_builder_visibility_hrrr_ops_all_hrrr():
     """
     This test verifies that data is returned for each fcstLen and each threshold.
@@ -467,6 +471,7 @@ def test_ctc_builder_visibility_hrrr_ops_all_hrrr():
                 continue
 
 
+@pytest.mark.integration()
 def test_ctc_ceiling_data_hrrr_ops_all_hrrr():
     """
     This test is a comprehensive test of the ctcBuilder data. It will retrieve CTC documents
@@ -599,6 +604,7 @@ def test_ctc_ceiling_data_hrrr_ops_all_hrrr():
                 the derived CTC {field}: {_ctc_value} and caclulated CTC {field}: {_cb_ctc_value} values do not match"""
 
 
+@pytest.mark.integration()
 def test_ctc_visibiltiy_data_hrrr_ops_all_hrrr():
     """
     This test is a comprehensive test of the ctcBuilder data. It will retrieve CTC documents

--- a/tests/vxingest/ctc_to_cb/test_unit_metar_ctc.py
+++ b/tests/vxingest/ctc_to_cb/test_unit_metar_ctc.py
@@ -31,6 +31,7 @@ def setup_ingest():
     return _vx_ingest, vx_ingest_manager
 
 
+@pytest.mark.integration()
 def test_cb_connect_disconnect():
     """test the cb connect and close"""
     vx_ingest_manager = None
@@ -49,6 +50,7 @@ def test_cb_connect_disconnect():
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_credentials_and_load_spec():
     """test the get_credentials and load_spec"""
     vx_ingest_manager = None
@@ -63,6 +65,7 @@ def test_credentials_and_load_spec():
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_write_load_job_to_files(tmp_path):
     """test write the load job"""
     vx_ingest_manager = None
@@ -79,6 +82,7 @@ def test_write_load_job_to_files(tmp_path):
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_build_load_job_doc():
     """test the build load job"""
     vx_ingest_manager = None

--- a/tests/vxingest/ctc_to_cb/test_unit_queries_ctc.py
+++ b/tests/vxingest/ctc_to_cb/test_unit_queries_ctc.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -43,6 +44,7 @@ def connect_cb():
     return cb_connection
 
 
+@pytest.mark.integration()
 def test_epoch_fcstlen_model(request):
     _name = request.node.name
     _expected_time = 3.0
@@ -60,6 +62,7 @@ def test_epoch_fcstlen_model(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_epoch_fcstlen_obs(request):
     _name = request.node.name
     _expected_time = 0.2
@@ -77,6 +80,7 @@ def test_epoch_fcstlen_obs(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_forecast_valid_epoch(request):
     _name = request.node.name
     _expected_time = 6.0
@@ -94,6 +98,7 @@ def test_forecast_valid_epoch(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_region_lat_lon(request):
     _name = request.node.name
     _expected_time = 0.01
@@ -111,6 +116,7 @@ def test_get_region_lat_lon(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_stations(request):
     _name = request.node.name
     _expected_time = 3
@@ -128,6 +134,7 @@ def test_get_stations(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_threshold_descriptions(request):
     _name = request.node.name
     _expected_time = 0.01

--- a/tests/vxingest/grib2_to_cb/test_int_metar_model_grib.py
+++ b/tests/vxingest/grib2_to_cb/test_int_metar_model_grib.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 from multiprocessing import Queue
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -64,6 +65,7 @@ def connect_cb():
         return cb_connection
 
 
+@pytest.mark.integration()
 def test_grib_builder_one_thread_file_pattern_hrrr_ops_conus(tmp_path):
     """test gribBuilder with one thread.
     This test verifies the resulting data file against the one that is in couchbase already
@@ -174,6 +176,7 @@ def test_grib_builder_one_thread_file_pattern_hrrr_ops_conus(tmp_path):
                     {_k}.{_dk} {result['data'][_k][_dk]} != {_json['data'][_k][_dk]} within {abs_tol} decimal places."""
 
 
+@pytest.mark.integration()
 def test_grib_builder_two_threads_file_pattern_hrrr_ops_conus(tmp_path):
     """test gribBuilder multi-threaded
     Not going to qulify the data on this one, just make sure it runs two threads properly
@@ -205,6 +208,7 @@ def test_grib_builder_two_threads_file_pattern_hrrr_ops_conus(tmp_path):
     )
 
 
+@pytest.mark.integration()
 def test_grib_builder_two_threads_file_pattern_rap_ops_130_conus(tmp_path):
     """test gribBuilder multi-threaded
     Not going to qulify the data on this one, just make sure it runs two threads properly

--- a/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
@@ -29,6 +29,7 @@ def setup_connection():
     return _vx_ingest
 
 
+@pytest.mark.integration()
 def test_credentials_and_load_spec():
     """test the get_credentials and load_spec"""
     vx_ingest = None
@@ -41,6 +42,7 @@ def test_credentials_and_load_spec():
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_credentials_and_load_spec_multiple_ingest_ids():
     """test the get_credentials and load_spec"""
     vx_ingest = None
@@ -53,6 +55,7 @@ def test_credentials_and_load_spec_multiple_ingest_ids():
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_cb_connect_disconnect():
     """test the cb connect and close"""
     vx_ingest = None
@@ -68,6 +71,7 @@ def test_cb_connect_disconnect():
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_write_load_job_to_files(tmp_path):
     """test write the load job"""
     vx_ingest = None
@@ -83,6 +87,7 @@ def test_write_load_job_to_files(tmp_path):
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_build_load_job_doc(tmp_path):
     """test the build load job"""
     vx_ingest = None
@@ -102,6 +107,7 @@ def test_build_load_job_doc(tmp_path):
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_vxingest_get_file_list(tmp_path):
     """test the vxingest get_file_list"""
     vx_ingest = None

--- a/tests/vxingest/grib2_to_cb/test_unit_proj.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_proj.py
@@ -18,6 +18,7 @@ def setup_connection():
     return _vx_ingest
 
 
+@pytest.mark.integration()
 def test_proj():
     """test the proj"""
     vx_ingest = None

--- a/tests/vxingest/grib2_to_cb/test_unit_proj_nocb.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_proj_nocb.py
@@ -1,7 +1,9 @@
 import pyproj
+import pytest
 import xarray as xr
 
 
+@pytest.mark.integration()
 def test_proj_nocb():
     """test the proj"""
     ds_height_above_ground_2m = xr.open_dataset(

--- a/tests/vxingest/grib2_to_cb/test_unit_queries_grib.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_queries_grib.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -43,6 +44,7 @@ def connect_cb():
     return cb_connection
 
 
+@pytest.mark.integration()
 def test_ingest_document_id(request):
     _name = request.node.name
     _expected_time = 0.02
@@ -60,6 +62,7 @@ def test_ingest_document_id(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_ingest_document_fields(request):
     _name = request.node.name
     _expected_time = 0.01
@@ -79,6 +82,7 @@ def test_ingest_document_fields(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_df(request):
     _name = request.node.name
     _expected_time = 18
@@ -96,6 +100,7 @@ def test_get_df(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_stations(request):
     _name = request.node.name
     _expected_time = 1
@@ -113,6 +118,7 @@ def test_get_stations(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_model_by_fcst_valid_epoch(request):
     _name = request.node.name
     _expected_time = 1.2

--- a/tests/vxingest/netcdf_to_cb/test_int_metar_obs_netcdf.py
+++ b/tests/vxingest/netcdf_to_cb/test_int_metar_obs_netcdf.py
@@ -54,6 +54,7 @@ def assert_dicts_almost_equal(dict1, dict2, rel_tol=1e-09):
             ), f"Values for {key} do not match"
 
 
+@pytest.mark.integration()
 def test_one_thread_specify_file_pattern(tmp_path):
     log_queue = Queue()
     vx_ingest = VXIngest()
@@ -114,6 +115,7 @@ def test_one_thread_specify_file_pattern(tmp_path):
     assert_dicts_almost_equal(derived_obs, retrieved_obs)
 
 
+@pytest.mark.integration()
 def test_two_threads_spedicfy_file_pattern(tmp_path):
     """
     integration test for testing multithreaded capability
@@ -148,6 +150,7 @@ def test_two_threads_spedicfy_file_pattern(tmp_path):
     ), "number of output files is incorrect"
 
 
+@pytest.mark.integration()
 def test_one_thread_default(tmp_path):
     """This test will start one thread of the ingestManager and simply make sure it runs with no Exceptions.
     It will attempt to process any files that are in the input directory that match the file_name_mask.
@@ -184,6 +187,7 @@ def test_one_thread_default(tmp_path):
     ), "number of output files is incorrect"
 
 
+@pytest.mark.integration()
 def test_two_threads_default(tmp_path):
     """This test will start one thread of the ingestManager and simply make sure it runs with no Exceptions.
     It will attempt to process any files that are in the input directory that atch the file_name_mask.

--- a/tests/vxingest/netcdf_to_cb/test_unit_metar_obs_netcdf.py
+++ b/tests/vxingest/netcdf_to_cb/test_unit_metar_obs_netcdf.py
@@ -30,6 +30,7 @@ def setup_connection():
     return _vx_ingest
 
 
+@pytest.mark.integration()
 def test_credentials_and_load_spec():
     """test the get_credentials and load_spec"""
     try:
@@ -41,6 +42,7 @@ def test_credentials_and_load_spec():
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_cb_connect_disconnect():
     """test the cb connect and close"""
     try:
@@ -55,6 +57,7 @@ def test_cb_connect_disconnect():
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_write_load_job_to_files(tmp_path):
     """test write the load job"""
     try:
@@ -70,6 +73,7 @@ def test_write_load_job_to_files(tmp_path):
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_build_load_job_doc(tmp_path):
     """test the build load job"""
     try:
@@ -87,6 +91,7 @@ def test_build_load_job_doc(tmp_path):
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_umask_value_transform():
     """test the derive_valid_time_epoch
     requires file_name which should match the format for grib2 hrr_ops files
@@ -130,6 +135,7 @@ def test_umask_value_transform():
         _nc.close()  # close returns memoryview
 
 
+@pytest.mark.integration()
 def test_vxingest_get_file_list(tmp_path):
     """test the vxingest get_file_list"""
     try:
@@ -204,6 +210,7 @@ def test_vxingest_get_file_list(tmp_path):
         vx_ingest.close_cb()
 
 
+@pytest.mark.integration()
 def test_interpolate_time():
     """test the interpolate time routine in netcdf_builder"""
     vx_ingest = setup_connection()
@@ -253,6 +260,7 @@ def test_interpolate_time():
             ), f"{1636390800 - delta} interpolated to {t_interpolated} is not equal"
 
 
+@pytest.mark.integration()
 def test_interpolate_time_iso():
     """test the interpolate time routine in netcdf_builder"""
     vx_ingest = setup_connection()
@@ -298,6 +306,7 @@ def test_interpolate_time_iso():
             ), f"{1636390800 - delta} interpolated to {t_interpolated} is not equal"
 
 
+@pytest.mark.integration()
 def test_handle_station():
     """Tests the ability to add or update a station with these possibilities...
     1) The station is new and there is no station document that yet exists so
@@ -676,6 +685,7 @@ def assert_station(cluster, station_zbaa, builder):
         )
 
 
+@pytest.mark.integration()
 def test_derive_valid_time_epoch():
     """test the derive_valid_time_epoch routine in netcdf_builder"""
     vx_ingest = setup_connection()
@@ -694,6 +704,7 @@ def test_derive_valid_time_epoch():
     ), f"derived epoch {derived_epoch} is not equal to 1636329600"
 
 
+@pytest.mark.integration()
 def test_derive_valid_time_iso():
     """test the derive_valid_time_iso routine in netcdf_builder"""
     vx_ingest = setup_connection()

--- a/tests/vxingest/netcdf_to_cb/test_unit_queries_obs.py
+++ b/tests/vxingest/netcdf_to_cb/test_unit_queries_obs.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -42,6 +43,7 @@ def connect_cb():
     return cb_connection
 
 
+@pytest.mark.integration()
 def test_ingest_document_id(request):
     _name = request.node.name
     _expected_time = 0.005
@@ -61,6 +63,7 @@ def test_ingest_document_id(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_ingest_document_fields(request):
     _name = request.node.name
     _expected_time = 0.005
@@ -80,6 +83,7 @@ def test_ingest_document_fields(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_stations(request):
     _name = request.node.name
     _expected_time = 0.01
@@ -97,6 +101,7 @@ def test_get_stations(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_obs_by_fcst_valid_epoch(request):
     _name = request.node.name
     _expected_time = 1

--- a/tests/vxingest/partial_sums_to_cb/test_int_metar_partial_sums.py
+++ b/tests/vxingest/partial_sums_to_cb/test_int_metar_partial_sums.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from multiprocessing import Queue
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -35,6 +36,7 @@ def stub_worker_log_configurer(queue: Queue):
     pass
 
 
+@pytest.mark.integration()
 def test_check_fcst_valid_epoch_fcst_valid_iso():
     """
     integration test to check fcst_valid_epoch is derived correctly
@@ -80,6 +82,7 @@ def test_check_fcst_valid_epoch_fcst_valid_iso():
         assert (fve % 3600) == 0, "fcstValidEpoch is not at top of hour"
 
 
+@pytest.mark.integration()
 def test_get_stations_geo_search():
     """
     Currently we know that there are differences between the geo search stations list and the legacy
@@ -167,6 +170,7 @@ def test_get_stations_geo_search():
         ), "difference between expected and actual greater than 100"
 
 
+@pytest.mark.integration()
 def test_ps_builder_surface_hrrr_ops_all_hrrr():
     """
     This test verifies that data is returned for each fcstLen.
@@ -242,6 +246,7 @@ def test_ps_builder_surface_hrrr_ops_all_hrrr():
         assert _elem is not None, "fcstLen not found in output"
 
 
+@pytest.mark.integration()
 def test_ps_surface_data_hrrr_ops_all_hrrr():
     """
     This test is a comprehensive test of the partialSumsBuilder data. It will retrieve SUMS documents

--- a/tests/vxingest/partial_sums_to_cb/test_unit_metar_partial_sums.py
+++ b/tests/vxingest/partial_sums_to_cb/test_unit_metar_partial_sums.py
@@ -29,6 +29,7 @@ def setup_ingest():
     return _vx_ingest, vx_ingest_manager
 
 
+@pytest.mark.integration()
 def test_cb_connect_disconnect():
     """test the cb connect and close"""
     vx_ingest_manager = None
@@ -47,6 +48,7 @@ def test_cb_connect_disconnect():
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_credentials_and_load_spec():
     """test the get_credentials and load_spec"""
     vx_ingest_manager = None
@@ -61,6 +63,7 @@ def test_credentials_and_load_spec():
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_write_load_job_to_files(tmp_path):
     """test write the load job"""
     vx_ingest_manager = None
@@ -77,6 +80,7 @@ def test_write_load_job_to_files(tmp_path):
             vx_ingest_manager.close_cb()
 
 
+@pytest.mark.integration()
 def test_build_load_job_doc(tmp_path):
     """test the build load job"""
     vx_ingest_manager = None

--- a/tests/vxingest/partial_sums_to_cb/test_unit_queries.py
+++ b/tests/vxingest/partial_sums_to_cb/test_unit_queries.py
@@ -2,6 +2,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
 import yaml
 from couchbase.auth import PasswordAuthenticator
 from couchbase.cluster import Cluster
@@ -43,6 +44,7 @@ def connect_cb():
     return cb_connection
 
 
+@pytest.mark.integration()
 def test_epoch_fcstlen_model(request):
     _name = request.node.name
     _expected_time = 3.0
@@ -62,6 +64,7 @@ def test_epoch_fcstlen_model(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_epoch_fcstlen_obs(request):
     _name = request.node.name
     _expected_time = 0.2
@@ -81,6 +84,7 @@ def test_epoch_fcstlen_obs(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_forecast_valid_epoch(request):
     _name = request.node.name
     _expected_time = 4.0
@@ -100,6 +104,7 @@ def test_forecast_valid_epoch(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_region_lat_lon(request):
     _name = request.node.name
     _expected_time = 0.01
@@ -119,6 +124,7 @@ def test_get_region_lat_lon(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_stations(request):
     _name = request.node.name
     _expected_time = 3
@@ -136,6 +142,7 @@ def test_get_stations(request):
     ), f"{_name}: elasped_time greater than {_expected_time} {elapsed_time}"
 
 
+@pytest.mark.integration()
 def test_get_threshold_descriptions(request):
     _name = request.node.name
     _expected_time = 0.01


### PR DESCRIPTION
This change:

* Adds a pytest marker for tests that we can't run in CI
* Adds a CI job to run our unit tests
* Adds a tool that can generate code coverage reports to our dependencies
* Runs that tools to generate coverage reports in CI

Note that this means that CI is only running a handful of tests at the moment. We need to do more work to make the test suite compatible with CI.