### PR TITLE
move the Begin a_time log message into the VxIngest class where it should have been all along. That is what was breaking the scraper, along with the reformatted log message preamble.

### DIFF
--- a/scripts/VXingest_utilities/scrape_metrics.sh
+++ b/scripts/VXingest_utilities/scrape_metrics.sh
@@ -111,10 +111,10 @@ if [ -z "${textfile_dir}" ]; then
 fi
 
 metric_name=$(grep 'metric_name' ${log_file} | awk '{print $2}')
-start_epoch=$(date -d "$(grep  'Begin a_time:' ${log_file} | awk '{print $3" "$4}')" +"%s")
+start_epoch=$(date -d "$(grep  'Begin a_time:' ${log_file} | awk '{print $7" "$8}')" +"%s")
 is_epoch_rational ${start_epoch}
 
-finish_epoch=$(date -d "$(grep  'End a_time:' ${log_file} | awk '{print $3" "$4}')" +"%s")
+finish_epoch=$(date -d "$(grep  'End a_time:' ${log_file} | awk '{print $7" "$8}')" +"%s")
 is_epoch_rational ${finish_epoch}
 
 #Get the error count from the log file

--- a/src/vxingest/ctc_to_cb/run_ingest_threads.py
+++ b/src/vxingest/ctc_to_cb/run_ingest_threads.py
@@ -86,10 +86,6 @@ def parse_args(args):
     """
     Parse command line arguments
     """
-    begin_time = str(datetime.now())
-    logger.info("--- *** --- Start --- *** ---")
-    logger.info("Begin a_time: %s", begin_time)
-    # a_time execution
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-j",
@@ -170,6 +166,10 @@ class VXIngest(CommonVxIngest):
         The method creates multiprocess "Process"es so expects a queue to pass log messages back
         on and a logger configuration function to format them
         """
+        begin_time = str(datetime.now())
+        logger.info("--- *** --- Start --- *** ---")
+        logger.info("Begin a_time: %s", begin_time)
+
         self.credentials_file = args["credentials_file"].strip()
         self.thread_count = args["threads"]
         self.output_dir = args["output_dir"].strip()

--- a/src/vxingest/grib2_to_cb/run_ingest_threads.py
+++ b/src/vxingest/grib2_to_cb/run_ingest_threads.py
@@ -86,10 +86,6 @@ def parse_args(args):
     """
     Parse command line arguments
     """
-    begin_time = str(datetime.now())
-    logger.info("--- *** --- Start --- *** ---")
-    logger.info("Begin a_time: %s", begin_time)
-    # a_time execution
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-j",
@@ -171,6 +167,10 @@ class VXIngest(CommonVxIngest):
         The file_pattern is a glob pattern that is used to match filenames that are derived from the path and file_mask.
         The file_mask is specified in the load_spec. The file_pattern is specified on the command line.
         """
+        begin_time = str(datetime.now())
+        logger.info("--- *** --- Start --- *** ---")
+        logger.info("Begin a_time: %s", begin_time)
+
         self.credentials_file = args["credentials_file"].strip()
         self.thread_count = args["threads"]
         self.output_dir = args["output_dir"].strip()

--- a/src/vxingest/netcdf_to_cb/run_ingest_threads.py
+++ b/src/vxingest/netcdf_to_cb/run_ingest_threads.py
@@ -86,10 +86,6 @@ def parse_args(args):
     """
     Parse command line arguments
     """
-    begin_time = str(datetime.now())
-    logger.info("--- *** --- Start --- *** ---")
-    logger.info("Begin a_time: %s", begin_time)
-    # a_time execution
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-j",
@@ -159,6 +155,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry point for run_ingest_threads.py
         """
+        begin_time = str(datetime.now())
+        logger.info("--- *** --- Start --- *** ---")
+        logger.info("Begin a_time: %s", begin_time)
+
         self.credentials_file = args["credentials_file"].strip()
         self.thread_count = args["threads"]
         self.output_dir = args["output_dir"].strip()

--- a/src/vxingest/partial_sums_to_cb/run_ingest_threads.py
+++ b/src/vxingest/partial_sums_to_cb/run_ingest_threads.py
@@ -86,10 +86,6 @@ def parse_args(args):
     """
     Parse command line arguments
     """
-    begin_time = str(datetime.now())
-    logger.info("--- *** --- Start --- *** ---")
-    logger.info("Begin a_time: %s", begin_time)
-    # a_time execution
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-j",
@@ -167,6 +163,10 @@ class VXIngest(CommonVxIngest):
         """
         This is the entry point for run_ingest_threads.py
         """
+        begin_time = str(datetime.now())
+        logger.info("--- *** --- Start --- *** ---")
+        logger.info("Begin a_time: %s", begin_time)
+
         self.credentials_file = args["credentials_file"].strip()
         self.thread_count = args["threads"]
         self.output_dir = args["output_dir"].strip()


### PR DESCRIPTION
The Begin a_time log message was incorrectly placed in the parse routine of the run_ingest, instead of in the runit routine. This in combination with the longer log preamble was breaking the scraper. 