### PR TITLE
fix issue 313 - file globbing not working the way it used to.

### DIFF
--- a/src/vxingest/grib2_to_cb/run_ingest_threads.py
+++ b/src/vxingest/grib2_to_cb/run_ingest_threads.py
@@ -240,7 +240,9 @@ class VXIngest(CommonVxIngest):
             AND originType='{model}'
             order by url;
             """
-        file_names = self.get_file_list(file_query, self.path, self.file_pattern, self.fmask)
+        file_names = self.get_file_list(
+            file_query, self.path, self.file_pattern, self.fmask
+        )
         for _f in file_names:
             _q.put(_f)
 

--- a/src/vxingest/grib2_to_cb/run_ingest_threads.py
+++ b/src/vxingest/grib2_to_cb/run_ingest_threads.py
@@ -21,7 +21,7 @@ The job document might look like this...
   "subDoc": "MODEL",
   "subDocType": "HRRR",
   "run_priority": 2,
-  "file_pattern": "%y%j%H%f",
+  "file_mask": "%y%j%H%f",
   "schedule": "0 * * * *",
   "offset_minutes": 0,
   "ingest_document_ids": [
@@ -29,13 +29,13 @@ The job document might look like this...
   ]
 }
 The important run time fields are "file_mask" and "ingest_document_ids".
-The file mask is a python time.strftime that specifies what files will
-be chosen based on pattern matching.
+The file mask is a python time.strftime that specifies how to interpret the file names with respect to time.
+These file names represent the validTime of the data in the file.
 The ingest_document_ids specify a list of ingest_document ids that a job
 must process.The script maintains a thread pool of VxIngestManagers and a queue of
 filenames that are derived from the path and file_mask.
-If a file_pattern is provided globbing is used to qualify which filenames in the input_path
-are included for ingesting.
+If the optional file_pattern parameter is provided, globbing is used to qualify which filenames in the input_path
+are included for ingesting. The deafult is to include all files in the input_path i.e. "*".
 The number of threads in the thread pool is set to the -t n (or --threads n)
 argument, where n is the number of threads to start. The default is one thread.
 The optional -n number_stations will restrict the processing to n number of stations to limit run time.
@@ -240,7 +240,7 @@ class VXIngest(CommonVxIngest):
             AND originType='{model}'
             order by url;
             """
-        file_names = self.get_file_list(file_query, self.path, self.file_pattern)
+        file_names = self.get_file_list(file_query, self.path, self.file_pattern, self.fmask)
         for _f in file_names:
             _q.put(_f)
 
@@ -250,7 +250,6 @@ class VXIngest(CommonVxIngest):
         ingest_manager_list = []
         for thread_count in range(int(self.thread_count)):
             try:
-                self.load_spec["fmask"] = self.fmask
                 ingest_manager_thread = VxIngestManager(
                     "VxIngestManager-" + str(thread_count),
                     self.load_spec,

--- a/src/vxingest/netcdf_to_cb/run_ingest_threads.py
+++ b/src/vxingest/netcdf_to_cb/run_ingest_threads.py
@@ -224,7 +224,9 @@ class VXIngest(CommonVxIngest):
             AND originType='madis' order by url;
             """
         # file_pattern is a glob string not a python file match string
-        file_names = self.get_file_list(file_query, self.path, self.file_pattern, self.fmask)
+        file_names = self.get_file_list(
+            file_query, self.path, self.file_pattern, self.fmask
+        )
         for _f in file_names:
             _q.put(_f)
 

--- a/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
@@ -114,7 +114,7 @@ def test_vxingest_get_file_list(tmp_path):
     try:
         vx_ingest = setup_connection()
         vx_ingest.load_job_id = "test_id"
-        pattern = '%Y%m%d_%H%M'
+        pattern = "%Y%m%d_%H%M"
         # order is important to see if the files are getting returned sorted by mtime, not name
         Path(tmp_path / "20210920_1701").touch()
         Path(tmp_path / "20210920_1702").touch()

--- a/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
+++ b/tests/vxingest/grib2_to_cb/test_unit_metar_model_grib.py
@@ -114,15 +114,16 @@ def test_vxingest_get_file_list(tmp_path):
     try:
         vx_ingest = setup_connection()
         vx_ingest.load_job_id = "test_id"
-        # order is important to see if the files are getting returned sorted by mtime
-        Path(tmp_path / "f_fred_01").touch()
-        Path(tmp_path / "f_fred_02").touch()
-        Path(tmp_path / "f_fred_04").touch()
-        Path(tmp_path / "f_fred_05").touch()
-        Path(tmp_path / "f_fred_03").touch()
-        Path(tmp_path / "f_1_fred_01").touch()
-        Path(tmp_path / "f_2_fred_01").touch()
-        Path(tmp_path / "f_3_fred_01").touch()
+        pattern = '%Y%m%d_%H%M'
+        # order is important to see if the files are getting returned sorted by mtime, not name
+        Path(tmp_path / "20210920_1701").touch()
+        Path(tmp_path / "20210920_1702").touch()
+        Path(tmp_path / "20210920_1704").touch()
+        Path(tmp_path / "20210920_1705").touch()
+        Path(tmp_path / "20210920_1703").touch()
+        Path(tmp_path / "20210921_1701").touch()
+        Path(tmp_path / "20210922_1701").touch()
+        Path(tmp_path / "20210923_1701").touch()
         query = f""" SELECT url, mtime
             From `{vx_ingest.cb_credentials['bucket']}`.{vx_ingest.cb_credentials['scope']}.{vx_ingest.cb_credentials['collection']}
             WHERE
@@ -131,13 +132,13 @@ def test_vxingest_get_file_list(tmp_path):
             AND fileType='grib2'
             AND originType='model'
             AND model='HRRR_OPS' order by url;"""
-        files = vx_ingest.get_file_list(query, tmp_path, "f_fred_*")
+        files = vx_ingest.get_file_list(query, tmp_path, "20210920_17*", pattern)
         assert True, files == [
-            tmp_path / "f_fred_01",
-            tmp_path / "f_fred_02",
-            tmp_path / "f_fred_04",
-            tmp_path / "f_fred_05",
-            tmp_path / "f_fred_03",
+            tmp_path / "20210920_1701",
+            tmp_path / "20210920_1702",
+            tmp_path / "20210920_1704",
+            tmp_path / "20210920_1705",
+            tmp_path / "20210920_1703",
         ]
     except Exception as _e:
         pytest.fail(f"test_build_load_job_doc Exception failure: {_e}")

--- a/tests/vxingest/netcdf_to_cb/test_unit_metar_obs_netcdf.py
+++ b/tests/vxingest/netcdf_to_cb/test_unit_metar_obs_netcdf.py
@@ -161,6 +161,8 @@ def test_vxingest_get_file_list(tmp_path):
         # make a ".prev" and a ".tmp" directory to see if they get filtered out
         Path(tmp_path / ".prev").mkdir()
         Path(tmp_path / ".tmp").mkdir()
+        # put a properly formed file (different name) into the .prev directory
+        Path(tmp_path / ".prev/1820017010000").touch()
         # order is important to see if the files are getting returned sorted by mtime
         Path(tmp_path / "1820013010000").touch()
         Path(tmp_path / "1820013020000").touch()

--- a/tests/vxingest/partial_sums_to_cb/test_int_metar_partial_sums.py
+++ b/tests/vxingest/partial_sums_to_cb/test_int_metar_partial_sums.py
@@ -186,7 +186,7 @@ def test_ps_builder_surface_hrrr_ops_all_hrrr():
     global stations
 
     credentials_file = os.environ["CREDENTIALS"]
-    job_id = "JOB-TEST:V01:METAR:SUMS:SURFACE:MODEL:OPS"
+    job_id = "JOB-TEST:V01:METAR:PARTIAL_SUMS:SURFACE:MODEL:OPS"
     outdir = Path("/opt/data/test/partial_sums_to_cb/hrrr_ops/sums/output")
     if not outdir.exists():
         # Create a new directory because it does not exist


### PR DESCRIPTION
The ingest file selection was picking up ".prev" and ".tmp" as file names and adding them to the queue. These directories are part of the ITS file transfer mechanism and should be ignored.

This PR adds a filter to the get_file_list method such that it takes the file mask parameter that is defined in the JOB document and tries to derive a timestamp from applying the mask to the basename of each selected  file. Every valid files' name should reflect the mask and be able to be datetime.strptime 'd into a valid timestamp.