### PR TITLE
Update the python tooling in the ingest container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true
-          # Use a cache to speed up builds
-          # Note: this may cause security issues if the apt updates are cached
-          # It may make more sense to build eccodes as its own image instead.
-          cache-from: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache
-          cache-to: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache,mode=max
+          # # Use a cache to speed up builds
+          # # Note: this may cause security issues if the apt updates are cached
+          # # It may make more sense to build eccodes as its own image instead.
+          # cache-from: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache
+          # cache-to: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache,mode=max
   build-import:
     name: Build Import image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true
-          # # Use a cache to speed up builds
-          # # Note: this may cause security issues if the apt updates are cached
-          # # It may make more sense to build eccodes as its own image instead.
-          # cache-from: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache
-          # cache-to: type=registry,ref=ghcr.io/noaa-gsl/vxingest/cache/ingest:buildcache,mode=max
   build-import:
     name: Build Import image
     runs-on: ubuntu-latest
@@ -168,12 +163,23 @@ jobs:
         uses: aquasecurity/trivy-action@0.23.0
         with:
           image-ref: "ghcr.io/noaa-gsl/vxingest/ingest:sha-${{ env.SHORT_SHA }}"
+          format: "table" # Generate actionable output
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          exit-code: "1"
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate Trivy output formatted for the GitHub Security tab
+        if: always()
+        uses: aquasecurity/trivy-action@0.23.0
+        with:
+          image-ref: "ghcr.io/noaa-gsl/vxingest/ingest:sha-${{ env.SHORT_SHA }}"
           format: "sarif"
           output: "trivy-ingest-results.sarif"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
           limit-severities-for-sarif: true
-          exit-code: "1"
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -193,12 +199,23 @@ jobs:
         uses: aquasecurity/trivy-action@0.23.0
         with:
           image-ref: "ghcr.io/noaa-gsl/vxingest/import:sha-${{ env.SHORT_SHA }}"
+          format: "table" # Generate actionable output
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH"
+          # exit-code: "1" # FIXME: allow failures for now. Couchbase needs to update cbtools
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate Trivy output formatted for the GitHub Security tab
+        if: always()
+        uses: aquasecurity/trivy-action@0.23.0
+        with:
+          image-ref: "ghcr.io/noaa-gsl/vxingest/import:sha-${{ env.SHORT_SHA }}"
           format: "sarif"
           output: "trivy-import-results.sarif"
           ignore-unfixed: true
           severity: "CRITICAL,HIGH"
           limit-severities-for-sarif: true
-          # exit-code: "1" # FIXME: allow failures for now. Couchbase needs to update cbtools
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/ingest/Dockerfile
+++ b/docker/ingest/Dockerfile
@@ -7,6 +7,9 @@ FROM python:3.11-slim-bookworm AS eccodes
 
 ARG ECCODES_VER=2.32.1
 
+# Update the built in Python tooling
+RUN pip install --no-cache-dir --upgrade pip setuptools
+
 RUN apt-get update && \
     apt-get install -y curl wget && \
     apt-get install -y build-essential libssl-dev libnetcdff-dev libopenjp2-7-dev gfortran make unzip git cmake && \

--- a/docker/ingest/Dockerfile
+++ b/docker/ingest/Dockerfile
@@ -111,6 +111,9 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y libopenjp2-7 libaec0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
 
+# Update the built in Python tooling
+RUN pip install --no-cache-dir --upgrade pip setuptools
+
 # Copy just the vxingest app
 COPY ./src/ /app/
 

--- a/docker/ingest/Dockerfile
+++ b/docker/ingest/Dockerfile
@@ -7,9 +7,6 @@ FROM python:3.11-slim-bookworm AS eccodes
 
 ARG ECCODES_VER=2.32.1
 
-# Update the built in Python tooling
-RUN pip install --no-cache-dir --upgrade pip setuptools
-
 RUN apt-get update && \
     apt-get install -y curl wget && \
     apt-get install -y build-essential libssl-dev libnetcdff-dev libopenjp2-7-dev gfortran make unzip git cmake && \
@@ -43,6 +40,7 @@ RUN apt-get update && \
     apt-get install -y build-essential && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
 
+# Make sure the python tooling is up-to-date for when it's copied into the prod layer
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir poetry
 
@@ -84,6 +82,9 @@ ENV VERSION=${BUILDVER}
 
 LABEL version=${BUILDVER} code.branch=${COMMITBRANCH} code.commit=${COMMITSHA}
 
+# Update the image's built in Python tooling before we activate the virtual environment
+RUN pip install --no-cache-dir --upgrade pip setuptools
+
 # Activate the virtual environment
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
@@ -113,9 +114,6 @@ RUN apt-get update && apt-get upgrade -y && \
     # Install runtime deps for the native eccodes library
     apt-get install -y libopenjp2-7 libaec0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
-
-# Update the built in Python tooling
-RUN pip install --no-cache-dir --upgrade pip setuptools
 
 # Copy just the vxingest app
 COPY ./src/ /app/


### PR DESCRIPTION
We were updating the python tooling (`setuptools` & friends) in the builder layer but forgot to update them in the prod layer. This resulted in a `setuptools` vulnerability blocking CI. 

This PR:
- updates `setuptools` & friends in the correct locations in the docker image
- removes the docker build caching in CI as it wasn't doing anything. (I made #404 to address this)
- Updates the security scanning step in CI to add more actionable output.