### PR TITLE
Update cbtools to match the database version

### DIFF
--- a/docker/import/Dockerfile
+++ b/docker/import/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)" && \
     curl -L https://github.com/nalbury/promql-cli/releases/download/${PROMQL_VERSION}/promql-${PROMQL_VERSION}-linux-$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/).tar.gz | tar xz --directory /usr/local/bin
 
 # Install the couchbase tools
-ARG CB_VERSION=7.2.2
+ARG CB_VERSION=7.6.2
 RUN curl -L https://packages.couchbase.com/releases/${CB_VERSION}/couchbase-server-tools_${CB_VERSION}-linux_$(uname -m).tar.gz | tar xz --directory /usr/local
 
 # Copy the scripts and metadata dirs so the import script can run


### PR DESCRIPTION
We observed some issues using an old version of cbtools with the latest version of the database. Update them in the image to ensure they remain in sync.