### PR TITLE
Disable CI path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,21 @@
 name: "VxIngest CI"
 on:
   push:
-    paths-ignore:
-      - "meta_update_middleware/**"
-      - "docs/**"
+    # For now, run this job on all changes. Path
+    # filtering & required checks don't mix well.
+    # paths-ignore:
+    #   - "meta_update_middleware/**"
+    #   - "docs/**"
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
     branches: [main]
   pull_request:
-    paths-ignore:
-      - "meta_update_middleware/**"
-      - "docs/**"
+    # For now, run this job on all changes. Path
+    # filtering & required checks don't mix well.
+    # paths-ignore:
+    #   - "meta_update_middleware/**"
+    #   - "docs/**"
   workflow_dispatch: # Manually
 env:
   REGISTRY: ghcr.io/noaa-gsl/vxingest


### PR DESCRIPTION
CI path filtering doesn't work well with required checks - PRs that don't match the path are forever stuck in a pending state.